### PR TITLE
Tick build: 0 -> 1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
      - python35-compat.patch  # [py35]
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
   {{ hash_type }}: {{ hash_val }}
   patches:
      - python35-compat.patch  # [py35]
+     # this patch is taken from upstream; see https://bitbucket.org/catherinedevlin/cmd2/issues/18/python-35-renames-subprocessmswindows
 
 build:
   number: 1


### PR DESCRIPTION
Should have ticked this when applying patch, but didn't. Ticking build to force rebuild and run for Python 3.5.